### PR TITLE
Encode the 'id' URL component before AJAX requests

### DIFF
--- a/jquery.socialist.js
+++ b/jquery.socialist.js
@@ -50,7 +50,7 @@
                             nw.cb=function(newElement){queue.push(newElement)};
                             var reqUrl = nw.url;
                             // replace params in request url
-                            reqUrl = reqUrl.replace("|id|",item.id);
+                            reqUrl = reqUrl.replace("|id|",encodeURIComponent(item.id));
                             reqUrl = reqUrl.replace("|areaName|",item.areaName);
                             reqUrl = reqUrl.replace("|apiKey|",item.apiKey);
                             reqUrl = reqUrl.replace("|num|",settings.maxResults);

--- a/jquery.socialist.js
+++ b/jquery.socialist.js
@@ -49,6 +49,16 @@
                             var nw = helpers.networkDefs[item.name];
                             nw.cb=function(newElement){queue.push(newElement)};
                             var reqUrl = nw.url;
+                            // force url to be http or https
+                            if (typeof item.secure !== 'undefined') {
+                                var protocol;
+                                switch (item.secure) {
+                                    case true:     protocol = 'https://'; break;
+                                    case false:    protocol = 'http://';  break;
+                                    case 'detect': protocol = '//';       break;
+                                }
+                                reqUrl = reqUrl.replace(/^https?:\/\//,protocol);
+                            }
                             // replace params in request url
                             reqUrl = reqUrl.replace("|id|",encodeURIComponent(item.id));
                             reqUrl = reqUrl.replace("|areaName|",item.areaName);


### PR DESCRIPTION
The Google Feed API can't process URLs that contain unencoded ampersands or other special characters. This fix encodes them properly before sending the AJAX request.
