### PR TITLE
Allow user to specify https or https protocol for AJAX calls

### DIFF
--- a/jquery.socialist.js
+++ b/jquery.socialist.js
@@ -49,6 +49,16 @@
                             var nw = helpers.networkDefs[item.name];
                             nw.cb=function(newElement){queue.push(newElement)};
                             var reqUrl = nw.url;
+                            // force url to be http or https
+                            if (typeof item.secure !== 'undefined') {
+                                var protocol;
+                                switch (item.secure) {
+                                    case true:     protocol = 'https://'; break;
+                                    case false:    protocol = 'http://';  break;
+                                    case 'detect': protocol = '//';       break;
+                                }
+                                reqUrl = reqUrl.replace(/^https?:\/\//,protocol);
+                            }
                             // replace params in request url
                             reqUrl = reqUrl.replace("|id|",item.id);
                             reqUrl = reqUrl.replace("|areaName|",item.areaName);


### PR DESCRIPTION
This enhancement allows the developer to force AJAX connections to use http://, https://, or auto-detect based on the protocol of the current URL. It can be useful when jQuery Socialist is embedded on an https:// page; some browsers will fail to retrieve the Google Feed API using an http:// URL.

This is accomplished by adding a "secure" property in the networks config, as such:

```
$('#socialist').socialist({
    networks: [
        { name:'rss', id:'http://www.rssfeedurl.com/', secure:true }
    ]
});
```

Possible values for 'secure' are: true, false, "detect". If 'secure' is not specified, then it defaults to whatever protocol is set in the networkDefs object.
