### PR TITLE
Encode the 'id' URL component before AJAX requests

### DIFF
--- a/jquery.socialist.js
+++ b/jquery.socialist.js
@@ -50,7 +50,7 @@
                             nw.cb=function(newElement){queue.push(newElement)};
                             var reqUrl = nw.url;
                             // replace params in request url
-                            reqUrl = reqUrl.replace("|id|",item.id);
+                            reqUrl = reqUrl.replace("|id|",encodeURIComponent(item.id));
                             reqUrl = reqUrl.replace("|areaName|",item.areaName);
                             reqUrl = reqUrl.replace("|apiKey|",item.apiKey);
                             reqUrl = reqUrl.replace("|num|",settings.maxResults);


### PR DESCRIPTION
The Google Feed API can't process URLs that contain unencoded ampersands or other special characters. This fix encodes them properly before sending the AJAX request.
